### PR TITLE
Task: CircleCI runs unit tests [GG-31]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,23 +8,29 @@ jobs:
     working_directory: ~/GreeterGuru
     docker:
       - image: circleci/python:3.7.3
+        environment:
+          PIPENV_VENV_IN_PROJECT: true
+          DATABASE_URL: sqlite:///GGProject/GreeterGuru/db.sqlite3
     steps:
       - checkout
-      - restore_cache: # ensure this step occurs *before* install dependencies
-          key: deps10-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+      # - restore_cache: # ensure this step occurs *before* install dependencies
+      #    key: deps10-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run: 
           command: | # use pipenv to install dependencies
-            sudo pip install pipenv
-            pipenv install 
-            pipenv run python GGProject/manage.py test
-      - save_cache:
-          key: deps10-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
-          paths:
-            - '.venv'
-            - '/usr/local/bin'
+            source venv/bin/activate
+            sudo python -m pip install -r requirements.txt
+            cd GGProject
+            python manage.py makemigrations
+            python manage.py migrate
+            python manage.py test
+      # - save_cache:
+      #     key: deps10-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+      #     paths:
+      #       - '.venv'
+      #       - '/usr/local/bin'
       - run:
           command: |
-            pipenv run python GGProject/manage.py test
+            python GGProject/manage.py test
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,28 @@
 version: 2
 jobs:
   build:
+    working_directory: ~/GreeterGuru
     docker:
-      - image: circleci/ruby:2.4.1
+      - image: circleci/python:3.7.3
     steps:
       - checkout
-      - run: echo "A first hello"
+      - restore_cache: # ensure this step occurs *before* install dependencies
+          key: deps10-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+      - run: 
+          command: | # use pipenv to install dependencies
+            sudo pip install pipenv
+            pipenv install 
+            pipenv run python GGProject/manage.py test
+      - save_cache:
+          key: deps10-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          paths:
+            - '.venv'
+            - '/usr/local/bin'
+      - run:
+          command: |
+            pipenv run python GGProject/manage.py test
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          path: test-results
+          destination: tr1

--- a/FaceID/faceid_test.py
+++ b/FaceID/faceid_test.py
@@ -1,6 +1,7 @@
 import requests, json, getpass
 from django.core.files import File
 
+# FIXME: This is known currently fail on Django Unit Testing
 
 # Create authentication header containing admin token
 def authenticate():


### PR DESCRIPTION
CircleCI is now set up to

- activate the virtual environment
- install all dependencies used in the project
- make migrations on any changes to the models
- migrate the models the the embedded db (SQLite3)
- run the unit test suite

Note: This only works with unit tests in the GGProject directory. To get CircleCI to correctly run, we must ommit FaceID/test.py from running by renaming the file. 

This can be fixed in another ticket, but it is out of scope for this ticket.
